### PR TITLE
chore(travis): Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: node_js
 
 before_install:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
 
 node_js:
   - '0.10'
 
 before_script:
-  - 'npm install'
+# - 'npm run lint'
 
-after_script: "npm install coveralls@2.10.0 && cat ./coverage/lcov.info | coveralls"
+after_script:
+  - 'npm install coveralls@2.10.0 && cat ./coverage/lcov.info | coveralls'

--- a/package.json
+++ b/package.json
@@ -28,6 +28,6 @@
     "mocha": "^3.0.2"
   },
   "scripts": {
-     "test": "./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha -- -u exports test/*"
+    "test": "istanbul cover ./node_modules/mocha/bin/_mocha -- -u exports test/*.js"
   }
 }


### PR DESCRIPTION
This fixes the build.

`xvfb` wasn’t being used anywhere, so starting it was pointless, and starting it manually broke the build when **Travis** migrated to **Ubuntu 16 Xenial**, which no longer has an executable at `/etc/init.d/xvfb`.